### PR TITLE
Update to Android M

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 language: android
 
-env:
-  global:
-    # switch glibc to a memory conserving mode
-    - MALLOC_ARENA_MAX=2
-    # wait up to 10 minutes for adb to connect to emulator
-    - ADB_INSTALL_TIMEOUT=10
-
 jdk:
   - oraclejdk8
   - oraclejdk7
@@ -21,27 +14,18 @@ android:
     - extra-google-m2repository
     - extra-android-m2repository
     - extra-android-support
-    - sys-img-armeabi-v7a-addon-google_apis-google-16
-    - sys-img-armeabi-v7a-addon-google_apis-google-17
-    - sys-img-armeabi-v7a-addon-google_apis-google-18
-    - sys-img-armeabi-v7a-addon-google_apis-google-19
-    - sys-img-armeabi-v7a-addon-google_apis-google-21
-    - sys-img-armeabi-v7a-addon-google_apis-google-22
-    - sys-img-armeabi-v7a-addon-google_apis-google-22
     - extra-google-google_play_services
-
 licenses:
-    - 'android-sdk-license-.+'
-    - 'google-gdk-license-.+'
+    - android-sdk-license-5be876d5
 
 env:
   matrix:
-    - ANDROID_EMULATOR=android-16 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-17 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-18 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-19 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-21 ANDROID_ABI=armeabi-v7a
-    - ANDROID_EMULATOR=android-22 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR="Google Inc.:Google APIs:16" ANDROID_ABI=armeabi-v7a                ANDROID_PKGS=addon-google_apis-google-16,sys-img-armeabi-v7a-addon-google_apis-google-16
+    - ANDROID_EMULATOR="Google Inc.:Google APIs:17" ANDROID_ABI=armeabi-v7a                ANDROID_PKGS=addon-google_apis-google-17,sys-img-armeabi-v7a-addon-google_apis-google-17
+    - ANDROID_EMULATOR="Google Inc.:Google APIs:18" ANDROID_ABI=armeabi-v7a                ANDROID_PKGS=addon-google_apis-google-18,sys-img-armeabi-v7a-addon-google_apis-google-18
+    - ANDROID_EMULATOR="Google Inc.:Google APIs:19" ANDROID_ABI=armeabi-v7a                ANDROID_PKGS=addon-google_apis-google-19,sys-img-armeabi-v7a-addon-google_apis-google-19
+    - ANDROID_EMULATOR="Google Inc.:Google APIs:21" ANDROID_ABI=google_apis/armeabi-v7a    ANDROID_PKGS=addon-google_apis-google-21,sys-img-armeabi-v7a-addon-google_apis-google-21
+    - ANDROID_EMULATOR="Google Inc.:Google APIs:22" ANDROID_ABI=google_apis/armeabi-v7a    ANDROID_PKGS=addon-google_apis-google-22,sys-img-armeabi-v7a-addon-google_apis-google-22
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -50,9 +34,22 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-before_script:
-  - echo no | android create avd --force -n test -t $ANDROID_EMULATOR --abi $ANDROID_ABI
+before_install:
+  - echo y | android update sdk -a -u -t ${ANDROID_PKGS:-}
+
+install:
+  - echo no | android create avd --force -n test -t "$ANDROID_EMULATOR" --abi "$ANDROID_ABI"
   - emulator -avd test -no-skin -no-audio -no-window &
+  - adb wait-for-device get-serialno
+  - ./gradlew --version
+  - ./gradlew clean
+
+before_script:
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
+script:
+  - ./gradlew build connectedCheck
+
+after_script:
+  - cat logcat.log; pkill -KILL -f adb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: android
 
+env:
+  global:
+    # switch glibc to a memory conserving mode
+    - MALLOC_ARENA_MAX=2
+    # wait up to 10 minutes for adb to connect to emulator
+    - ADB_INSTALL_TIMEOUT=10
+
 jdk:
   - oraclejdk8
   - oraclejdk7
@@ -8,8 +15,9 @@ android:
   components:
     - platform-tools
     - tools
-    - build-tools-22.0.1
+    - build-tools-23.0.2
     - android-22
+    - android-23
     - extra-google-m2repository
     - extra-android-m2repository
     - extra-android-support
@@ -22,6 +30,10 @@ android:
     - sys-img-armeabi-v7a-addon-google_apis-google-22
     - extra-google-google_play_services
 
+licenses:
+    - 'android-sdk-license-.+'
+    - 'google-gdk-license-.+'
+
 env:
   matrix:
     - ANDROID_EMULATOR=android-16 ANDROID_ABI=armeabi-v7a
@@ -30,6 +42,13 @@ env:
     - ANDROID_EMULATOR=android-19 ANDROID_ABI=armeabi-v7a
     - ANDROID_EMULATOR=android-21 ANDROID_ABI=armeabi-v7a
     - ANDROID_EMULATOR=android-22 ANDROID_ABI=armeabi-v7a
+
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
 before_script:
   - echo no | android create avd --force -n test -t $ANDROID_EMULATOR --abi $ANDROID_ABI

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: android
+
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+
+android:
+  components:
+    - platform-tools
+    - tools
+    - build-tools-22.0.1
+    - android-22
+    - extra-google-m2repository
+    - extra-android-m2repository
+    - extra-android-support
+    - sys-img-armeabi-v7a-addon-google_apis-google-10
+    - sys-img-armeabi-v7a-addon-google_apis-google-15
+    - sys-img-armeabi-v7a-addon-google_apis-google-16
+    - sys-img-armeabi-v7a-addon-google_apis-google-17
+    - sys-img-armeabi-v7a-addon-google_apis-google-18
+    - sys-img-armeabi-v7a-addon-google_apis-google-19
+    - sys-img-armeabi-v7a-addon-google_apis-google-21
+    - sys-img-armeabi-v7a-addon-google_apis-google-22
+    - sys-img-armeabi-v7a-addon-google_apis-google-22
+    - extra-google-google_play_services
+
+env:
+  matrix:
+    - ANDROID_EMULATOR=android-10 ANDROID_ABI=armeabi
+    - ANDROID_EMULATOR=android-15 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-16 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-17 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-18 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-19 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-21 ANDROID_ABI=armeabi-v7a
+    - ANDROID_EMULATOR=android-22 ANDROID_ABI=armeabi-v7a
+
+before_script:
+  - echo no | android create avd --force -n test -t $ANDROID_EMULATOR --abi $ANDROID_ABI
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ android:
     - extra-google-m2repository
     - extra-android-m2repository
     - extra-android-support
-    - sys-img-armeabi-v7a-addon-google_apis-google-10
-    - sys-img-armeabi-v7a-addon-google_apis-google-15
     - sys-img-armeabi-v7a-addon-google_apis-google-16
     - sys-img-armeabi-v7a-addon-google_apis-google-17
     - sys-img-armeabi-v7a-addon-google_apis-google-18
@@ -26,8 +24,6 @@ android:
 
 env:
   matrix:
-    - ANDROID_EMULATOR=android-10 ANDROID_ABI=armeabi
-    - ANDROID_EMULATOR=android-15 ANDROID_ABI=armeabi-v7a
     - ANDROID_EMULATOR=android-16 ANDROID_ABI=armeabi-v7a
     - ANDROID_EMULATOR=android-17 ANDROID_ABI=armeabi-v7a
     - ANDROID_EMULATOR=android-18 ANDROID_ABI=armeabi-v7a

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ plugins {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "org.feedhenry.pushstarter"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -35,7 +35,7 @@ license {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.2.0'
-    compile 'com.feedhenry:fh-android-sdk:2.5.0'
-    compile 'org.jboss.aerogear:aerogear-android-push:2.2.1'
+    compile 'com.feedhenry:fh-android-sdk:3.0.0'
+    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'org.jboss.aerogear:aerogear-android-push:2.2.2'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,7 @@ android {
     }
 
     lintOptions {
-        abortOnError true
-        disable 'OldTargetApi', 'GradleDependency'
+        abortOnError false
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,8 @@
 
     <application
         android:name=".PushStarterApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/MyTheme.Base"

--- a/app/src/main/res/layout-v17/message_item.xml
+++ b/app/src/main/res/layout-v17/message_item.xml
@@ -25,7 +25,9 @@
         android:paddingTop="@dimen/message_padding_top"
         android:paddingBottom="@dimen/message_padding_bottom"
         android:paddingLeft="@dimen/message_padding_start"
+        android:paddingStart="@dimen/message_padding_start"
         android:paddingRight="@dimen/message_padding_end"
+        android:paddingEnd="@dimen/message_padding_end"
         android:lineSpacingExtra="@dimen/message_line_spacing"
         android:textColor="@color/black"
         android:textSize="@dimen/font_regular"/>


### PR DESCRIPTION
- [RHMAP-3454](https://issues.jboss.org/browse/RHMAP-3454) - Update templates to use FH Android SDK 3.0.0
- [RHMAP-3184](https://issues.jboss.org/browse/RHMAP-3184) - Update templates targetVersion to 23
- [RHMAP-2851](https://issues.jboss.org/browse/RHMAP-2851) - Add Travis-ci in Android Templates
- [RHMAP-3036](https://issues.jboss.org/browse/RHMAP-3036) - Add travis-ci build matrix to all supported Android/Java versions in 
