### PR TITLE
Moving Travis build over to GCE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ android:
     - extra-google-google_play_services
 licenses:
     - android-sdk-license-5be876d5
-sudo: false
+sudo: required
+dist: precise
 env:
   matrix:
     - ANDROID_EMULATOR="Google Inc.:Google APIs:16" ANDROID_ABI=armeabi-v7a                ANDROID_PKGS=addon-google_apis-google-16,sys-img-armeabi-v7a-addon-google_apis-google-16


### PR DESCRIPTION
Moving away from Container based build, over to GCE, where we get 7.5 GB of RAM
