### PR TITLE
Making tests same license headers

### DIFF
--- a/app/src/androidTestTravis/java/org/feedhenry/pushstarter/ApplicationTest.java
+++ b/app/src/androidTestTravis/java/org/feedhenry/pushstarter/ApplicationTest.java
@@ -1,19 +1,19 @@
 /**
  * Copyright 2015 Red Hat, Inc., and individual contributors
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.feedhenry.pushstarter;
+ package org.feedhenry.pushstarter;
 
 import android.app.Application;
 import android.test.ApplicationTestCase;

--- a/app/src/androidTestTravis/java/org/feedhenry/pushstarter/StartupTests.java
+++ b/app/src/androidTestTravis/java/org/feedhenry/pushstarter/StartupTests.java
@@ -1,4 +1,19 @@
-package org.feedhenry.pushstarter;
+/**
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.feedhenry.pushstarter;
 
 import android.test.AndroidTestCase;
 


### PR DESCRIPTION
yes, still using 2015 - updates to include 2016 will be a different PR 
